### PR TITLE
Atualizando a versão do Pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests==2.22.0
 selenium==3.141.0
-Pillow==7.0.0
+Pillow==8.0.0


### PR DESCRIPTION
Percebi que o algoritmo não estava funcionando nas versões mais recentes do Python, isso estava ocorrendo pois o Pillow 7.0.0 não tem mais suporte ao Python 3.9.

Utilizando a Pillow 8.0.0 o algoritmo terá suporte em todas as versões do Python superiores ou iguais a 3.5.